### PR TITLE
fix: add functionality to manage test output directories in .gitignore

### DIFF
--- a/src/generator.js
+++ b/src/generator.js
@@ -2,7 +2,7 @@ import path from 'path';
 import chalk from 'chalk';
 import { validateProjectDirectory, pathExists } from './utils.js';
 import { getUserInput, confirmAction } from './prompts.js';
-import { generateTestFiles, testsDirectoryExists, getGeneratedFilesList, addTestsToEslintIgnore } from './file-operations.js';
+import { generateTestFiles, testsDirectoryExists, getGeneratedFilesList, addTestsToEslintIgnore, addTestOutputDirsToGitignore } from './file-operations.js';
 import { updatePackageJson, isPlaywrightInstalled, installDependencies, runBuildAndTests } from './package-updater.js';
 
 /**
@@ -62,6 +62,11 @@ export async function generator() {
 			if (eslintResult.updated) {
 				console.log(chalk.green('  ✓ Added tests/ to .eslintignore'));
 			}
+		}
+
+		const gitignoreResult = await addTestOutputDirsToGitignore(cwd);
+		if (gitignoreResult.updated) {
+			console.log(chalk.green('  ✓ Added test output dirs to .gitignore'));
 		}
 		
 		// Step 4: Update package.json


### PR DESCRIPTION
- Introduced `addTestOutputDirsToGitignore` function to append test output directories to .gitignore.
- Updated generator to call the new function and log changes to the user.