### PR TITLE
feat: enhance market selection and configuration handling in prompts …

### DIFF
--- a/description.md
+++ b/description.md
@@ -1,0 +1,86 @@
+The markets we have access to are:
+
+The UK (SEUK) - https://www.samsung.com/uk/
+
+Benelux (SEBN)
+
+Belgium (BENL) - https://www.samsung.com/be/
+
+Belgium (BEFR) - https://www.samsung.com/be_fr/
+
+Netherlands (NL) - https://www.samsung.com/nl/
+
+France (SEF) - https://www.samsung.com/fr/
+
+Germany (SEG) - https://www.samsung.com/de/
+
+Italy (SEI) - https://www.samsung.com/it/
+
+Nordics (SENA)
+
+Sweden - https://www.samsung.com/se/
+
+Norway - https://www.samsung.com/no/
+
+Denmark - https://www.samsung.com/de/
+
+Finland - https://www.samsung.com/fi/
+
+Poland (SEPOL) - https://www.samsung.com/pl/
+
+Iberia (SEIB)
+
+Spain (SEIB-ES) - https://www.samsung.com/es/
+
+Portugal (SEIB-PT) - https://www.samsung.com/pt/
+
+Canada (SECA) - https://www.samsung.com/ca/
+
+Europe
+
+Albania - https://www.samsung.com/al/
+
+Austria - https://www.samsung.com/at/  
+
+Bosnia - https://www.samsung.com/ba/  
+
+Bulgaria - https://www.samsung.com/bg/  
+
+Croatia - https://www.samsung.com/hr/  
+
+Czech - https://www.samsung.com/cz/  
+
+Estonia - https://www.samsung.com/ee/  
+
+Greece - https://www.samsung.com/gr/  
+
+Hungary - https://www.samsung.com/hu/  
+
+Ireland - https://www.samsung.com/ie/  
+
+Latvia - https://www.samsung.com/lv/  
+
+Lithuania - https://www.samsung.com/lt/  
+
+Macedonia - https://www.samsung.com/mk/
+
+Romania - https://www.samsung.com/ro/  
+
+Serbia - https://www.samsung.com/rs/  
+
+Slovakia - https://www.samsung.com/sk/  
+
+Slovenia - https://www.samsung.com/si/
+
+Switzerland - https://www.samsung.com/ch/
+
+
+
+experimentConfig - The implementing aproach in this repository is to have a single experimentConfig.js file that contains the experiment configuration.
+
+The configuration currently have only 1 market and as u see we have many markets.
+
+There are markets that include 2 or more countries, e.g SEBN, SENA etc!
+So for example SEBN includes - BE, BE_FR, NL!
+
+As an enhancement allow users to create tests for "SEBN" that would automatically result in three countries etc, so that the user doesn't have to type them manually.

--- a/src/file-operations.js
+++ b/src/file-operations.js
@@ -13,7 +13,7 @@ const TEMPLATES_DIR = path.join(__dirname, '..', 'templates');
  * @param {Object} config - Configuration object with user inputs
  */
 export async function generateTestFiles(targetDir, config) {
-	const { experimentName, baseUrl, market } = config;
+	const { experimentName, baseUrl, marketGroup, markets } = config;
 	const experimentNameKebab = toKebabCase(experimentName);
 	
 	// Template variables
@@ -21,7 +21,8 @@ export async function generateTestFiles(targetDir, config) {
 		EXPERIMENT_NAME: experimentName,
 		EXPERIMENT_NAME_KEBAB: experimentNameKebab,
 		BASE_URL: baseUrl,
-		MARKET: market.toUpperCase(),
+		MARKET_GROUP: marketGroup,
+		MARKETS_JSON: JSON.stringify(markets, null, '\t'),
 	};
 	
 	// Define file mappings: [source, destination]

--- a/src/generator.js
+++ b/src/generator.js
@@ -4,6 +4,7 @@ import { validateProjectDirectory, pathExists } from './utils.js';
 import { getUserInput, confirmAction } from './prompts.js';
 import { generateTestFiles, testsDirectoryExists, getGeneratedFilesList, addTestsToEslintIgnore, addTestOutputDirsToGitignore } from './file-operations.js';
 import { updatePackageJson, isPlaywrightInstalled, installDependencies, runBuildAndTests } from './package-updater.js';
+import { formatMarketCodes } from './markets.js';
 
 /**
  * Main generator function
@@ -45,6 +46,13 @@ export async function generator() {
 	// Step 2: Get user input
 	console.log(chalk.blue('\nPlease provide the following information:\n'));
 	const config = await getUserInput(cwd);
+	
+	// Display configuration summary
+	console.log(chalk.blue('\n📋 Configuration summary:'));
+	console.log(chalk.gray(`   Experiment: ${config.experimentName}`));
+	console.log(chalk.gray(`   Base URL: ${config.baseUrl}`));
+	console.log(chalk.gray(`   Market Group: ${config.marketGroup}`));
+	console.log(chalk.gray(`   Markets: ${formatMarketCodes(config.markets)}`));
 	
 	// Step 3: Generate files
 	console.log(chalk.blue('\n📁 Generating test files...\n'));
@@ -106,7 +114,13 @@ export async function generator() {
 			step++;
 		}
 		console.log(chalk.white(`  ${step}. Update test URLs in:`));
-		console.log(chalk.gray('     tests/config/qa-links.config.js\n'));
+		console.log(chalk.gray('     tests/config/qa-links.config.js'));
+		if (config.markets && config.markets.length > 1) {
+			console.log(chalk.gray(`     Configure URLs for each market: ${formatMarketCodes(config.markets)}`));
+			console.log(chalk.gray('     Or use environment variables: CONTROL_URL_<MARKET>, EXPERIMENT_URL_<MARKET>\n'));
+		} else {
+			console.log('');
+		}
 		step++;
 		console.log(chalk.white(`  ${step}. Customize test selectors in:`));
 		console.log(chalk.gray(`     tests/e2e/${config.experimentName.toLowerCase().replace(/\s+/g, '-')}/${config.experimentName.toLowerCase().replace(/\s+/g, '-')}.spec.js\n`));

--- a/src/markets.js
+++ b/src/markets.js
@@ -1,0 +1,226 @@
+export const MARKET_GROUPS = {
+	// Multi-country market groups
+	SEBN: {
+		name: 'Benelux',
+		countries: [
+			{ code: 'BE', urlPath: 'be', name: 'Belgium (NL)' },
+			{ code: 'BE_FR', urlPath: 'be_fr', name: 'Belgium (FR)' },
+			{ code: 'NL', urlPath: 'nl', name: 'Netherlands' },
+		],
+	},
+	SENA: {
+		name: 'Nordics',
+		countries: [
+			{ code: 'SE', urlPath: 'se', name: 'Sweden' },
+			{ code: 'NO', urlPath: 'no', name: 'Norway' },
+			{ code: 'DK', urlPath: 'dk', name: 'Denmark' },
+			{ code: 'FI', urlPath: 'fi', name: 'Finland' },
+		],
+	},
+	SEIB: {
+		name: 'Iberia',
+		countries: [
+			{ code: 'ES', urlPath: 'es', name: 'Spain' },
+			{ code: 'PT', urlPath: 'pt', name: 'Portugal' },
+		],
+	},
+
+	// Single-country market groups
+	SEUK: {
+		name: 'UK',
+		countries: [{ code: 'UK', urlPath: 'uk', name: 'United Kingdom' }],
+	},
+	SEF: {
+		name: 'France',
+		countries: [{ code: 'FR', urlPath: 'fr', name: 'France' }],
+	},
+	SEG: {
+		name: 'Germany',
+		countries: [{ code: 'DE', urlPath: 'de', name: 'Germany' }],
+	},
+	SEI: {
+		name: 'Italy',
+		countries: [{ code: 'IT', urlPath: 'it', name: 'Italy' }],
+	},
+	SEPOL: {
+		name: 'Poland',
+		countries: [{ code: 'PL', urlPath: 'pl', name: 'Poland' }],
+	},
+	SECA: {
+		name: 'Canada',
+		countries: [{ code: 'CA', urlPath: 'ca', name: 'Canada' }],
+	},
+
+	// Additional European markets
+	EUROPE_AL: {
+		name: 'Albania',
+		countries: [{ code: 'AL', urlPath: 'al', name: 'Albania' }],
+	},
+	EUROPE_AT: {
+		name: 'Austria',
+		countries: [{ code: 'AT', urlPath: 'at', name: 'Austria' }],
+	},
+	EUROPE_BA: {
+		name: 'Bosnia',
+		countries: [{ code: 'BA', urlPath: 'ba', name: 'Bosnia' }],
+	},
+	EUROPE_BG: {
+		name: 'Bulgaria',
+		countries: [{ code: 'BG', urlPath: 'bg', name: 'Bulgaria' }],
+	},
+	EUROPE_HR: {
+		name: 'Croatia',
+		countries: [{ code: 'HR', urlPath: 'hr', name: 'Croatia' }],
+	},
+	EUROPE_CZ: {
+		name: 'Czech Republic',
+		countries: [{ code: 'CZ', urlPath: 'cz', name: 'Czech Republic' }],
+	},
+	EUROPE_EE: {
+		name: 'Estonia',
+		countries: [{ code: 'EE', urlPath: 'ee', name: 'Estonia' }],
+	},
+	EUROPE_GR: {
+		name: 'Greece',
+		countries: [{ code: 'GR', urlPath: 'gr', name: 'Greece' }],
+	},
+	EUROPE_HU: {
+		name: 'Hungary',
+		countries: [{ code: 'HU', urlPath: 'hu', name: 'Hungary' }],
+	},
+	EUROPE_IE: {
+		name: 'Ireland',
+		countries: [{ code: 'IE', urlPath: 'ie', name: 'Ireland' }],
+	},
+	EUROPE_LV: {
+		name: 'Latvia',
+		countries: [{ code: 'LV', urlPath: 'lv', name: 'Latvia' }],
+	},
+	EUROPE_LT: {
+		name: 'Lithuania',
+		countries: [{ code: 'LT', urlPath: 'lt', name: 'Lithuania' }],
+	},
+	EUROPE_MK: {
+		name: 'Macedonia',
+		countries: [{ code: 'MK', urlPath: 'mk', name: 'Macedonia' }],
+	},
+	EUROPE_RO: {
+		name: 'Romania',
+		countries: [{ code: 'RO', urlPath: 'ro', name: 'Romania' }],
+	},
+	EUROPE_RS: {
+		name: 'Serbia',
+		countries: [{ code: 'RS', urlPath: 'rs', name: 'Serbia' }],
+	},
+	EUROPE_SK: {
+		name: 'Slovakia',
+		countries: [{ code: 'SK', urlPath: 'sk', name: 'Slovakia' }],
+	},
+	EUROPE_SI: {
+		name: 'Slovenia',
+		countries: [{ code: 'SI', urlPath: 'si', name: 'Slovenia' }],
+	},
+	EUROPE_CH: {
+		name: 'Switzerland',
+		countries: [{ code: 'CH', urlPath: 'ch', name: 'Switzerland' }],
+	},
+};
+
+/**
+ * Generate choices for the market selection prompt
+ * @returns {Array} - Array of choices for prompts autocomplete
+ */
+export function getMarketChoices() {
+	const choices = [];
+
+	// Add multi-country groups first (most useful)
+	const multiCountryGroups = ['SEBN', 'SENA', 'SEIB'];
+	multiCountryGroups.forEach((groupCode) => {
+		const group = MARKET_GROUPS[groupCode];
+		const countryCodes = group.countries.map((c) => c.code).join(', ');
+		choices.push({
+			title: `${groupCode} - ${group.name} (${countryCodes})`,
+			value: groupCode,
+			description: `Includes: ${countryCodes}`,
+		});
+	});
+
+	// Add single-country major markets
+	const majorMarkets = ['SEUK', 'SEF', 'SEG', 'SEI', 'SEPOL', 'SECA'];
+	majorMarkets.forEach((groupCode) => {
+		const group = MARKET_GROUPS[groupCode];
+		const country = group.countries[0];
+		choices.push({
+			title: `${groupCode} - ${group.name} (${country.code})`,
+			value: groupCode,
+			description: country.name,
+		});
+	});
+
+	// Add European markets
+	Object.entries(MARKET_GROUPS)
+		.filter(([code]) => code.startsWith('EUROPE_'))
+		.forEach(([groupCode, group]) => {
+			const country = group.countries[0];
+			choices.push({
+				title: `${country.code} - ${group.name}`,
+				value: groupCode,
+				description: country.name,
+			});
+		});
+
+	return choices;
+}
+
+/**
+ * Resolve market input to an array of market objects
+ * Handles both market group codes and individual market codes
+ * @param {string} marketInput - Market group code or individual market code
+ * @returns {{ marketGroup: string, markets: Array<{code: string, urlPath: string, name: string}> }}
+ */
+export function resolveMarkets(marketInput) {
+	const upperInput = marketInput.toUpperCase();
+
+	// Check if it's a known market group
+	if (MARKET_GROUPS[upperInput]) {
+		return {
+			marketGroup: upperInput,
+			markets: MARKET_GROUPS[upperInput].countries,
+		};
+	}
+
+	// Check if it matches a country code within any group
+	for (const [groupCode, group] of Object.entries(MARKET_GROUPS)) {
+		const matchingCountry = group.countries.find(
+			(c) => c.code.toUpperCase() === upperInput
+		);
+		if (matchingCountry) {
+			return {
+				marketGroup: groupCode,
+				markets: [matchingCountry],
+			};
+		}
+	}
+
+	// Treat as custom/unknown market - create a market object from the input
+	const urlPath = marketInput.toLowerCase().replace(/_/g, '_');
+	return {
+		marketGroup: upperInput,
+		markets: [
+			{
+				code: upperInput,
+				urlPath: urlPath,
+				name: upperInput,
+			},
+		],
+	};
+}
+
+/**
+ * Get a formatted string of market codes for display
+ * @param {Array<{code: string}>} markets - Array of market objects
+ * @returns {string} - Comma-separated list of market codes
+ */
+export function formatMarketCodes(markets) {
+	return markets.map((m) => m.code).join(', ');
+}

--- a/templates/tests/config/experiment.config.js
+++ b/templates/tests/config/experiment.config.js
@@ -4,7 +4,8 @@
  */
 export const experimentConfig = {
 	name: '{{EXPERIMENT_NAME}}',
-	market: '{{MARKET}}',
+	marketGroup: '{{MARKET_GROUP}}',
+	markets: '{{MARKETS_JSON}}',
 	baseUrl: '{{BASE_URL}}',
 	
 	// Experiment variants
@@ -25,4 +26,12 @@ export const experimentConfig = {
 	
 	// Adobe Target preview token (if applicable)
 	adobePreviewToken: process.env.ADOBE_PREVIEW_TOKEN || '',
+
+	getMarketCodes() {
+		return this.markets.map((m) => m.code);
+	},
+
+	getMarket(code) {
+		return this.markets.find((m) => m.code === code);
+	},
 };

--- a/templates/tests/config/qa-links.config.js
+++ b/templates/tests/config/qa-links.config.js
@@ -1,17 +1,73 @@
+/**
+ * QA Links configuration for multi-market testing
+ * Supports environment variables per market: CONTROL_URL_BE, EXPERIMENT_URL_NL, etc.
+ */
 export const qaLinksConfig = {
-	controlUrl: process.env.CONTROL_URL || '{{BASE_URL}}/{{MARKET}}/control-page/',
-	experimentUrl: process.env.EXPERIMENT_URL || '{{BASE_URL}}/{{MARKET}}/experiment-page/',
+	baseUrl: '{{BASE_URL}}',
+	markets: '{{MARKETS_JSON}}',
+
+	/**
+	 * Get URLs for a specific market
+	 * @param {string} marketCode - Market code (e.g., 'NL', 'BE')
+	 * @returns {{ controlUrl: string, experimentUrl: string }}
+	 */
+	getUrls(marketCode) {
+		const market = this.markets.find((m) => m.code === marketCode);
+		if (!market) {
+			throw new Error(`Unknown market code: ${marketCode}`);
+		}
+
+		return {
+			controlUrl:
+				process.env[`CONTROL_URL_${marketCode}`] ||
+				`${this.baseUrl}/${market.urlPath}/control-page/`,
+			experimentUrl:
+				process.env[`EXPERIMENT_URL_${marketCode}`] ||
+				`${this.baseUrl}/${market.urlPath}/experiment-page/`,
+		};
+	},
+
+	/**
+	 * Get URLs for all configured markets
+	 * @returns {Array<{ code: string, urlPath: string, name: string, controlUrl: string, experimentUrl: string }>}
+	 */
+	getAllUrls() {
+		return this.markets.map((market) => ({
+			...market,
+			...this.getUrls(market.code),
+		}));
+	},
+
+	/**
+	 * Get all market codes
+	 * @returns {string[]}
+	 */
+	getMarketCodes() {
+		return this.markets.map((m) => m.code);
+	},
 };
 
 /**
- * Validates that required URLs are configured
+ * Validates that required URLs are configured for all markets
  * @throws {Error} if required URLs are missing
  */
 export function validateUrls() {
-	if (!qaLinksConfig.controlUrl || !qaLinksConfig.experimentUrl) {
+	const missingUrls = [];
+
+	for (const market of qaLinksConfig.markets) {
+		const urls = qaLinksConfig.getUrls(market.code);
+		if (!urls.controlUrl) {
+			missingUrls.push(`CONTROL_URL_${market.code}`);
+		}
+		if (!urls.experimentUrl) {
+			missingUrls.push(`EXPERIMENT_URL_${market.code}`);
+		}
+	}
+
+	if (missingUrls.length > 0) {
 		throw new Error(
-			'Missing required URLs. Please set CONTROL_URL and EXPERIMENT_URL environment variables ' +
-			'or update the URLs in tests/config/qa-links.config.js'
+			`Missing required URLs. Please set the following environment variables ` +
+				`or update the URLs in tests/config/qa-links.config.js:\n${missingUrls.join(', ')}`
 		);
 	}
 }


### PR DESCRIPTION
Closes #2 

This PR adds **market aggregation support** to the Experiment E2E Test Generator so users can select market groups (e.g. SEBN, SENA, SEIB) that automatically expand to their constituent countries, and improves the **prompt UX** by replacing y/n confirmations with toggle-based choices.

- Updated `generateTestFiles` to include market group and markets in the configuration.
- Improved user input prompts to allow selection of market or market group with autocomplete functionality.
- Added configuration summary display for better user feedback.
- Enhanced QA links configuration to support multi-market testing with dynamic URL generation.
- Updated templates to reflect new market structure and added utility methods for market handling.