### PR TITLE
feat: add multi-market aggregation and fix template bugs

### DIFF
--- a/description.md
+++ b/description.md
@@ -22,7 +22,7 @@ Sweden - https://www.samsung.com/se/
 
 Norway - https://www.samsung.com/no/
 
-Denmark - https://www.samsung.com/de/
+Denmark - https://www.samsung.com/dk/
 
 Finland - https://www.samsung.com/fi/
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "publishConfig": {
         "access": "public"
     },
-    "version": "1.0.10",
+    "version": "1.0.11",
     "description": "CLI tool to generate Playwright e2e tests for Experiment Framework projects",
     "type": "module",
     "bin": {

--- a/src/file-operations.js
+++ b/src/file-operations.js
@@ -22,7 +22,7 @@ export async function generateTestFiles(targetDir, config) {
 		EXPERIMENT_NAME_KEBAB: experimentNameKebab,
 		BASE_URL: baseUrl,
 		MARKET_GROUP: marketGroup,
-		MARKETS_JSON: JSON.stringify(markets, null, '\t'),
+		MARKETS_JSON: JSON.stringify(markets),
 	};
 	
 	// Define file mappings: [source, destination]

--- a/templates/tests/config/experiment.config.js
+++ b/templates/tests/config/experiment.config.js
@@ -5,8 +5,8 @@
 export const experimentConfig = {
 	name: '{{EXPERIMENT_NAME}}',
 	marketGroup: '{{MARKET_GROUP}}',
-	markets: '{{MARKETS_JSON}}',
-	baseUrl: '{{BASE_URL}}',
+	markets: JSON.parse('{{MARKETS_JSON}}'),
+	baseUrl: '{{BASE_URL}}',	
 	
 	// Experiment variants
 	variants: {

--- a/templates/tests/config/qa-links.config.js
+++ b/templates/tests/config/qa-links.config.js
@@ -4,7 +4,7 @@
  */
 export const qaLinksConfig = {
 	baseUrl: '{{BASE_URL}}',
-	markets: '{{MARKETS_JSON}}',
+	markets: JSON.parse('{{MARKETS_JSON}}'),
 
 	/**
 	 * Get URLs for a specific market
@@ -52,22 +52,21 @@ export const qaLinksConfig = {
  * @throws {Error} if required URLs are missing
  */
 export function validateUrls() {
-	const missingUrls = [];
+	const missingEnvVars = [];
 
 	for (const market of qaLinksConfig.markets) {
-		const urls = qaLinksConfig.getUrls(market.code);
-		if (!urls.controlUrl) {
-			missingUrls.push(`CONTROL_URL_${market.code}`);
+		if (!process.env[`CONTROL_URL_${market.code}`]) {
+			missingEnvVars.push(`CONTROL_URL_${market.code}`);
 		}
-		if (!urls.experimentUrl) {
-			missingUrls.push(`EXPERIMENT_URL_${market.code}`);
+		if (!process.env[`EXPERIMENT_URL_${market.code}`]) {
+			missingEnvVars.push(`EXPERIMENT_URL_${market.code}`);
 		}
 	}
 
-	if (missingUrls.length > 0) {
-		throw new Error(
-			`Missing required URLs. Please set the following environment variables ` +
-				`or update the URLs in tests/config/qa-links.config.js:\n${missingUrls.join(', ')}`
+	if (missingEnvVars.length > 0) {
+		console.warn(
+			`Warning: The following environment variables are not set. ` +
+				`Falling back to default URL patterns:\n${missingEnvVars.join(', ')}`
 		);
 	}
 }

--- a/templates/tests/e2e/experiment-name/experiment.spec.js
+++ b/templates/tests/e2e/experiment-name/experiment.spec.js
@@ -4,7 +4,8 @@ import { qaLinksConfig, validateUrls } from '../../config/index.js';
 test.describe('{{EXPERIMENT_NAME}} - Control', () => {
 	test.beforeEach(async ({ page }) => {
 		validateUrls();
-		await page.goto(qaLinksConfig.controlUrl);
+		const { controlUrl } = qaLinksConfig.getUrls(qaLinksConfig.markets[0].code);
+		await page.goto(controlUrl);
 	});
 
 	test('should not display experiment component', async ({ page }) => {
@@ -25,7 +26,8 @@ test.describe('{{EXPERIMENT_NAME}} - Control', () => {
 test.describe('{{EXPERIMENT_NAME}} - Experiment', () => {
 	test.beforeEach(async ({ page }) => {
 		validateUrls();
-		await page.goto(qaLinksConfig.experimentUrl);
+		const { experimentUrl } = qaLinksConfig.getUrls(qaLinksConfig.markets[0].code);
+		await page.goto(experimentUrl);
 	});
 
 	test('should display experiment component', async ({ page }) => {

--- a/templates/tests/fixtures/test-fixtures.js
+++ b/templates/tests/fixtures/test-fixtures.js
@@ -13,7 +13,7 @@ export const test = base.extend({
 	experimentContext: async ({}, use) => {
 		const context = {
 			name: experimentConfig.name,
-			market: experimentConfig.market,
+			marketGroup: experimentConfig.marketGroup,
 			baseUrl: experimentConfig.baseUrl,
 			
 			/**


### PR DESCRIPTION
## Summary

- Add market aggregation system (`src/markets.js`) that auto-expands market groups (e.g., SEBN -> Belgium, Belgium FR, Netherlands) so users don't have to type countries manually
- Replace text input with autocomplete prompt for market selection, and y/n confirms with toggle UX
- Update all template files to support multi-market config (`marketGroup` + `markets` array)
- Fix 5 bugs in template files: markets stored as string instead of parsed array, broken API references in spec/fixtures, ineffective URL validation, and incorrect Denmark URL

## Test plan

- [ ] Run the generator CLI and select a multi-country market group (e.g., SEBN) -- verify it expands to BE, BE_FR, NL
- [ ] Run the generator with a single-country market (e.g., SEUK) -- verify it works as before
- [ ] Enter a custom market code not in the predefined list -- verify fallback handling
- [ ] Inspect generated `experiment.config.js` -- verify `markets` is a properly parsed array (not a string)
- [ ] Inspect generated `qa-links.config.js` -- verify `getUrls()`, `getAllUrls()`, `validateUrls()` work correctly
- [ ] Inspect generated `experiment.spec.js` -- verify it uses `getUrls()` API with first market code
- [ ] Inspect generated `test-fixtures.js` -- verify it references `marketGroup` (not removed `market` property)
- [ ] Run generated Playwright tests -- verify no runtime TypeErrors