### PR TITLE
Feat/page path scaffolding

### DIFF
--- a/src/file-operations.js
+++ b/src/file-operations.js
@@ -2,6 +2,7 @@ import path from 'path';
 import { fileURLToPath } from 'url';
 import fs from 'fs-extra';
 import { copyTemplateFile, toKebabCase } from './utils.js';
+import { buildPagePathsJs } from './page-paths.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -33,6 +34,7 @@ export async function generateTestFiles(targetDir, config) {
 		MARKET_GROUP: marketGroup,
 		MARKETS_JSON: JSON.stringify(markets),
 		COMPONENT_SELECTOR: componentSelector ?? buildFallbackSelector(experimentNameKebab),
+		PAGE_PATHS_JS: buildPagePathsJs(config.pagePaths ?? []),
 	};
 	
 	// Define file mappings: [source, destination]
@@ -43,6 +45,7 @@ export async function generateTestFiles(targetDir, config) {
 		// Config files
 		['tests/config/urls.config.js', 'tests/config/urls.config.js'],
 		['tests/config/experiment.config.js', 'tests/config/experiment.config.js'],
+		['tests/config/page-paths.config.js', 'tests/config/page-paths.config.js'],
 
 		// Test spec (with dynamic folder name)
 		[
@@ -87,6 +90,7 @@ export function getGeneratedFilesList(experimentName) {
 		'playwright.config.js',
 		'tests/config/urls.config.js',
 		'tests/config/experiment.config.js',
+		'tests/config/page-paths.config.js',
 		`tests/e2e/${experimentNameKebab}/experiment-test.spec.js`,
 	];
 }

--- a/src/generator.js
+++ b/src/generator.js
@@ -1,7 +1,7 @@
 import path from 'path';
 import chalk from 'chalk';
 import { validateProjectDirectory } from './utils.js';
-import { getUserInput, confirmAction, selectComponentSelector } from './prompts.js';
+import { getUserInput, confirmAction, selectComponentSelector, getPagePathSelections } from './prompts.js';
 import { scanForSelectors } from './selector-scanner.js';
 import { generateTestFiles, testsDirectoryExists, getGeneratedFilesList, addTestsToEslintIgnore, addTestOutputDirsToGitignore } from './file-operations.js';
 import { updatePackageJson, isPlaywrightInstalled, installDependencies, runBuildAndTests } from './package-updater.js';
@@ -55,6 +55,14 @@ export async function generator() {
 	console.log(chalk.gray(`   Market Group: ${config.marketGroup}`));
 	console.log(chalk.gray(`   Markets: ${formatMarketCodes(config.markets)}`));
 	
+	// Step 2.4: Get page path selections
+	console.log(chalk.blue('\n🗂  Which pages does this experiment run on?\n'));
+	const pagePaths = await getPagePathSelections();
+	if (pagePaths.length > 0) {
+		console.log(chalk.gray(`   Page paths: ${pagePaths.map(p => p.value).join(', ')}`));
+	}
+	config.pagePaths = pagePaths;
+
 	// Step 2.5: Scan for selectors
 	const selectorCandidates = await scanForSelectors(cwd);
 	if (selectorCandidates.length > 0) {

--- a/src/page-paths.js
+++ b/src/page-paths.js
@@ -1,0 +1,157 @@
+/**
+ * Samsung page-path catalogue for experiment test scaffolding.
+ *
+ * Four page types, each with a `type` field:
+ *   PFP  — Product Filter/Listing pages  (category listing grids)
+ *   PCD  — Product Category/Department   (top-level category hubs)
+ *   PDP  — Product Detail Pages          (individual product pages)
+ *   BUY  — Buy/Purchase pages            (buy flow for a product)
+ *
+ * Value keys are unique camelCase strings used as JS object keys in the
+ * generated pagePaths object and as test labels in Playwright output.
+ */
+export const PAGE_PATH_CHOICES = [
+	// ── PFP: Smartphones ─────────────────────────────────────────────────────
+	{ title: 'PFP · All Smartphones',        value: 'pfpSmartphonesAll',        path: '/smartphones/all-smartphones/',            type: 'PFP' },
+	{ title: 'PFP · Galaxy A',               value: 'pfpSmartphonesGalaxyA',    path: '/smartphones/galaxy-a/',                   type: 'PFP' },
+	{ title: 'PFP · Galaxy S',               value: 'pfpSmartphonesGalaxyS',    path: '/smartphones/galaxy-s/',                   type: 'PFP' },
+	{ title: 'PFP · Galaxy Z',               value: 'pfpSmartphonesGalaxyZ',    path: '/smartphones/galaxy-z/',                   type: 'PFP' },
+	// ── PFP: Tablets ─────────────────────────────────────────────────────────
+	{ title: 'PFP · All Tablets',            value: 'pfpTabletsAll',            path: '/tablets/all-tablets/',                    type: 'PFP' },
+	{ title: 'PFP · Galaxy Tab S',           value: 'pfpTabletsGalaxyTabS',     path: '/tablets/galaxy-tab-s/',                   type: 'PFP' },
+	{ title: 'PFP · Galaxy Tab A',           value: 'pfpTabletsGalaxyTabA',     path: '/tablets/galaxy-tab-a/',                   type: 'PFP' },
+	// ── PFP: Computers ───────────────────────────────────────────────────────
+	{ title: 'PFP · All Computers',          value: 'pfpComputersAll',          path: '/computers/all-computers/',                type: 'PFP' },
+	{ title: 'PFP · Galaxy Book',            value: 'pfpComputersGalaxyBook',   path: '/computers/galaxy-book/',                  type: 'PFP' },
+	{ title: 'PFP · Chromebook',             value: 'pfpComputersChromebook',   path: '/computers/chromebook/',                   type: 'PFP' },
+	// ── PFP: Monitors ────────────────────────────────────────────────────────
+	{ title: 'PFP · All Monitors',           value: 'pfpMonitorsAll',           path: '/monitors/all-monitors/',                  type: 'PFP' },
+	{ title: 'PFP · Gaming Monitors',        value: 'pfpMonitorsGaming',        path: '/monitors/gaming/',                        type: 'PFP' },
+	// ── PFP: Watches ─────────────────────────────────────────────────────────
+	{ title: 'PFP · All Watches',            value: 'pfpWatchesAll',            path: '/watches/all-watches/',                    type: 'PFP' },
+	{ title: 'PFP · Galaxy Watch',           value: 'pfpWatchesGalaxyWatch',    path: '/watches/galaxy-watch/',                   type: 'PFP' },
+	// ── PFP: TVs ─────────────────────────────────────────────────────────────
+	{ title: 'PFP · Neo QLED TVs',           value: 'pfpTvsNeoQled',            path: '/tvs/neo-qled-tvs/',                       type: 'PFP' },
+	{ title: 'PFP · OLED TVs',               value: 'pfpTvsOled',               path: '/tvs/oled-tvs/',                           type: 'PFP' },
+	{ title: 'PFP · QLED TVs',               value: 'pfpTvsQled',               path: '/tvs/qled-tvs/',                           type: 'PFP' },
+	{ title: 'PFP · 8K TVs',                 value: 'pfpTvs8k',                 path: '/tvs/8k-tv/',                              type: 'PFP' },
+	{ title: 'PFP · All TVs',                value: 'pfpTvsAll',                path: '/tvs/all-tvs/',                            type: 'PFP' },
+	{ title: 'PFP · Crystal UHD TVs',        value: 'pfpTvsCrystalUhd',         path: '/tvs/all-tvs/?crystal-uhd',                type: 'PFP' },
+	{ title: 'PFP · The Frame',              value: 'pfpLifestyleTheFrame',      path: '/lifestyle-tvs/the-frame/',                type: 'PFP' },
+	{ title: 'PFP · The Serif',              value: 'pfpLifestyleTheSerif',      path: '/lifestyle-tvs/the-serif/',                type: 'PFP' },
+	{ title: 'PFP · The Terrace',            value: 'pfpLifestyleTheTerrace',    path: '/lifestyle-tvs/the-terrace/',              type: 'PFP' },
+	{ title: 'PFP · The Sero',               value: 'pfpLifestyleTheSero',       path: '/lifestyle-tvs/the-sero/',                 type: 'PFP' },
+	// ── PFP: Audio ───────────────────────────────────────────────────────────
+	{ title: 'PFP · All Audio Devices',      value: 'pfpAudioAll',              path: '/audio-devices/all-audio-devices/',        type: 'PFP' },
+	// ── PFP: Refrigerators ───────────────────────────────────────────────────
+	{ title: 'PFP · All Refrigerators',      value: 'pfpRefrigeratorsAll',      path: '/refrigerators/all-refrigerators/',        type: 'PFP' },
+	{ title: 'PFP · Smart Refrigerators',    value: 'pfpRefrigSmart',           path: '/refrigerators/smart/',                    type: 'PFP' },
+	{ title: 'PFP · French Door',            value: 'pfpRefrigFrenchDoor',      path: '/refrigerators/french-door/',              type: 'PFP' },
+	{ title: 'PFP · Side-by-Side',           value: 'pfpRefrigSideBySide',      path: '/refrigerators/side-by-side/',             type: 'PFP' },
+	// ── PFP: Washers & Dryers ────────────────────────────────────────────────
+	{ title: 'PFP · All Washers & Dryers',   value: 'pfpWashersAll',            path: '/washers-and-dryers/all-washers-and-dryers/', type: 'PFP' },
+	{ title: 'PFP · Washing Machines',       value: 'pfpWashingMachines',       path: '/washers-and-dryers/washing-machines/',    type: 'PFP' },
+	{ title: 'PFP · Washer-Dryer Combo',     value: 'pfpWasherDryerCombo',      path: '/washers-and-dryers/washer-dryer-combo/',  type: 'PFP' },
+	{ title: 'PFP · Dryers',                 value: 'pfpDryers',                path: '/washers-and-dryers/dryers/',              type: 'PFP' },
+	// ── PFP: Cooking ─────────────────────────────────────────────────────────
+	{ title: 'PFP · All Cooking',            value: 'pfpCookingAll',            path: '/cooking-appliances/all-cooking-appliances/', type: 'PFP' },
+	{ title: 'PFP · Ovens',                  value: 'pfpCookingOvens',          path: '/cooking-appliances/ovens/',               type: 'PFP' },
+	{ title: 'PFP · Hobs',                   value: 'pfpCookingHobs',           path: '/cooking-appliances/hobs/',                type: 'PFP' },
+	{ title: 'PFP · Microwave Ovens',        value: 'pfpMicrowaveAll',          path: '/microwave-ovens/all-microwave-ovens/',    type: 'PFP' },
+	{ title: 'PFP · Hoods',                  value: 'pfpCookingHoods',          path: '/cooking-appliances/hoods/',               type: 'PFP' },
+	// ── PFP: Dishwashers / Vacuums ───────────────────────────────────────────
+	{ title: 'PFP · All Dishwashers',        value: 'pfpDishwashersAll',        path: '/dishwashers/all-dishwashers/',            type: 'PFP' },
+	{ title: 'PFP · All Vacuum Cleaners',    value: 'pfpVacuumAll',             path: '/vacuum-cleaners/all-vacuum-cleaners/',    type: 'PFP' },
+
+	// ── PCD: Top-level category hubs ─────────────────────────────────────────
+	{ title: 'PCD · Smartphones',            value: 'pcdSmartphones',           path: '/smartphones/',                            type: 'PCD' },
+	{ title: 'PCD · Tablets',                value: 'pcdTablets',               path: '/tablets/',                                type: 'PCD' },
+	{ title: 'PCD · Computers',              value: 'pcdComputers',             path: '/computers/',                              type: 'PCD' },
+	{ title: 'PCD · Monitors',               value: 'pcdMonitors',              path: '/monitors/',                               type: 'PCD' },
+	{ title: 'PCD · Watches',                value: 'pcdWatches',               path: '/watches/',                                type: 'PCD' },
+	{ title: 'PCD · TVs',                    value: 'pcdTvs',                   path: '/tvs/',                                    type: 'PCD' },
+	{ title: 'PCD · Lifestyle TVs',          value: 'pcdLifestyleTvs',          path: '/lifestyle-tvs/',                          type: 'PCD' },
+	{ title: 'PCD · Audio Devices',          value: 'pcdAudio',                 path: '/audio-devices/',                          type: 'PCD' },
+	{ title: 'PCD · Projectors',             value: 'pcdProjectors',            path: '/projectors/',                             type: 'PCD' },
+	{ title: 'PCD · Refrigerators',          value: 'pcdRefrigerators',         path: '/refrigerators/',                          type: 'PCD' },
+	{ title: 'PCD · Washers & Dryers',       value: 'pcdWashers',               path: '/washers-and-dryers/',                     type: 'PCD' },
+	{ title: 'PCD · Cooking',                value: 'pcdCooking',               path: '/cooking-appliances/',                     type: 'PCD' },
+	{ title: 'PCD · Dishwashers',            value: 'pcdDishwashers',           path: '/dishwashers/',                            type: 'PCD' },
+	{ title: 'PCD · Vacuum Cleaners',        value: 'pcdVacuum',                path: '/vacuum-cleaners/',                        type: 'PCD' },
+
+	// ── PDP: Product Detail Pages ─────────────────────────────────────────────
+	{ title: 'PDP · Galaxy Z Fold7',         value: 'pdpGalaxyZFold7',          path: '/smartphones/galaxy-z-fold7/',             type: 'PDP' },
+	{ title: 'PDP · Galaxy Z Flip7',         value: 'pdpGalaxyZFlip7',          path: '/smartphones/galaxy-z-flip7/',             type: 'PDP' },
+	{ title: 'PDP · Galaxy Z Flip7 FE',      value: 'pdpGalaxyZFlip7Fe',        path: '/smartphones/galaxy-z-flip7-fe/',          type: 'PDP' },
+	{ title: 'PDP · Galaxy S25',             value: 'pdpGalaxyS25',             path: '/smartphones/galaxy-s25/',                 type: 'PDP' },
+	{ title: 'PDP · Galaxy S25 Edge',        value: 'pdpGalaxyS25Edge',         path: '/smartphones/galaxy-s25-edge/',            type: 'PDP' },
+	{ title: 'PDP · Galaxy S25 Ultra',       value: 'pdpGalaxyS25Ultra',        path: '/smartphones/galaxy-s25-ultra/',           type: 'PDP' },
+	{ title: 'PDP · Galaxy Z Fold6',         value: 'pdpGalaxyZFold6',          path: '/smartphones/galaxy-z-fold6/',             type: 'PDP' },
+	{ title: 'PDP · Galaxy Z Flip6',         value: 'pdpGalaxyZFlip6',          path: '/smartphones/galaxy-z-flip6/',             type: 'PDP' },
+	{ title: 'PDP · Galaxy S24',             value: 'pdpGalaxyS24',             path: '/smartphones/galaxy-s24/',                 type: 'PDP' },
+	{ title: 'PDP · Galaxy S24 FE',          value: 'pdpGalaxyS24Fe',           path: '/smartphones/galaxy-s24-fe/',              type: 'PDP' },
+	{ title: 'PDP · Galaxy S24 Ultra',       value: 'pdpGalaxyS24Ultra',        path: '/smartphones/galaxy-s24-ultra/',           type: 'PDP' },
+
+	// ── BUY: Purchase pages ───────────────────────────────────────────────────
+	{ title: 'BUY · Galaxy Z Fold7',         value: 'buyGalaxyZFold7',          path: '/smartphones/galaxy-z-fold7/buy/',         type: 'BUY' },
+	{ title: 'BUY · Galaxy Z Flip7',         value: 'buyGalaxyZFlip7',          path: '/smartphones/galaxy-z-flip7/buy/',         type: 'BUY' },
+	{ title: 'BUY · Galaxy Z Flip7 FE',      value: 'buyGalaxyZFlip7Fe',        path: '/smartphones/galaxy-z-flip7-fe/buy/',      type: 'BUY' },
+	{ title: 'BUY · Galaxy S25',             value: 'buyGalaxyS25',             path: '/smartphones/galaxy-s25/buy/',             type: 'BUY' },
+	{ title: 'BUY · Galaxy S25 Edge',        value: 'buyGalaxyS25Edge',         path: '/smartphones/galaxy-s25-edge/buy/',        type: 'BUY' },
+	{ title: 'BUY · Galaxy S25 Ultra',       value: 'buyGalaxyS25Ultra',        path: '/smartphones/galaxy-s25-ultra/buy/',       type: 'BUY' },
+	{ title: 'BUY · Galaxy Z Fold6',         value: 'buyGalaxyZFold6',          path: '/smartphones/galaxy-z-fold6/buy/',         type: 'BUY' },
+	{ title: 'BUY · Galaxy Z Flip6',         value: 'buyGalaxyZFlip6',          path: '/smartphones/galaxy-z-flip6/buy/',         type: 'BUY' },
+	{ title: 'BUY · Galaxy S24',             value: 'buyGalaxyS24',             path: '/smartphones/galaxy-s24/buy/',             type: 'BUY' },
+	{ title: 'BUY · Galaxy S24 Ultra',       value: 'buyGalaxyS24Ultra',        path: '/smartphones/galaxy-s24-ultra/buy/',       type: 'BUY' },
+	{ title: 'BUY · Galaxy S24 FE',          value: 'buyGalaxyS24Fe',           path: '/smartphones/galaxy-s24-fe/buy/',          type: 'BUY' },
+];
+
+/**
+ * Build the choices array for the multiselect prompt, injecting non-selectable
+ * separator headers between page types so the terminal UI is scannable.
+ *
+ * The `prompts` library renders disabled entries as group headings.
+ *
+ * @returns {Array} choices array for prompts multiselect
+ */
+export function getPagePathPromptChoices() {
+	const typeLabels = {
+		PFP: '── PFP (Filter/Listing pages)',
+		PCD: '── PCD (Category hubs)',
+		PDP: '── PDP (Product Detail pages)',
+		BUY: '── BUY (Purchase pages)',
+	};
+	const choices = [];
+	let lastType = null;
+
+	for (const entry of PAGE_PATH_CHOICES) {
+		if (entry.type !== lastType) {
+			choices.push({ title: typeLabels[entry.type], disabled: true, value: `__sep_${entry.type}` });
+			lastType = entry.type;
+		}
+		choices.push({ title: entry.title.replace(/^[A-Z]+ · /, ''), value: entry.value });
+	}
+
+	return choices;
+}
+
+/**
+ * Convert an array of selected page-path entries to a JS object literal string
+ * suitable for injection as {{PAGE_PATHS_JS}} in templates.
+ *
+ * @param {Array<{value: string, path: string, type: string}>} selections
+ * @returns {string}
+ */
+export function buildPagePathsJs(selections) {
+	if (!selections || selections.length === 0) {
+		return [
+			'export const pagePaths = {',
+			'\t// TODO: add page paths your experiment targets',
+			"\t// pfpTvsAll: '/tvs/all-tvs/',",
+			'};',
+		].join('\n');
+	}
+
+	const entries = selections.map(({ value, path }) => `\t${value}: '${path}',`);
+	return ['export const pagePaths = {', ...entries, '};'].join('\n');
+}

--- a/templates/tests/config/page-paths.config.js
+++ b/templates/tests/config/page-paths.config.js
@@ -1,0 +1,6 @@
+/**
+ * Page paths for {{EXPERIMENT_NAME}} tests.
+ * Each key maps a descriptive label to a URL path segment.
+ * Tests iterate over all entries for each market.
+ */
+{{PAGE_PATHS_JS}}

--- a/templates/tests/config/urls.config.js
+++ b/templates/tests/config/urls.config.js
@@ -3,19 +3,15 @@
  *
  * bundlePath: path to your built experiment bundle, relative to project root.
  * Common values: 'dist/v1-index.jsx', 'dist/bundle.js', 'build/index.js'
- *
- * getUrl(marketCode): returns the production page URL to inject the bundle into.
- * Replace the path segment with a real product/landing page from your market.
  */
 export const urlsConfig = {
 	baseUrl: '{{BASE_URL}}',
 	bundlePath: 'dist/v1-index.jsx',
 	markets: {{MARKETS_JSON}},
 
-	getUrl(marketCode) {
+	getUrl(marketCode, pagePath) {
 		const market = this.markets.find(m => m.code === marketCode);
 		if (!market) throw new Error(`Unknown market: ${marketCode}`);
-		// TODO: replace '/smartphones/' with the page your experiment targets
-		return `${this.baseUrl}/${market.urlPath}/smartphones/`;
+		return `${this.baseUrl}/${market.urlPath}${pagePath}`;
 	},
 };

--- a/templates/tests/e2e/experiment-name/experiment-test.spec.js
+++ b/templates/tests/e2e/experiment-name/experiment-test.spec.js
@@ -2,6 +2,7 @@ import { test, expect } from '@playwright/test';
 import { readFileSync, existsSync } from 'fs';
 import { join } from 'path';
 import { urlsConfig } from '../../config/urls.config.js';
+import { pagePaths } from '../../config/page-paths.config.js';
 import { experimentConfig } from '../../config/experiment.config.js';
 
 const BUNDLE_PATH = join(process.cwd(), urlsConfig.bundlePath);
@@ -16,7 +17,7 @@ function loadBundle() {
 	return readFileSync(BUNDLE_PATH, 'utf8');
 }
 
-// ─── Tests run for every configured market ─────────────────────────────────
+// ─── Tests run for every configured market × page path ─────────────────────
 
 for (const market of experimentConfig.markets) {
 	test.describe(`{{EXPERIMENT_NAME}} — ${market.name} (${market.code})`, () => {
@@ -26,27 +27,32 @@ for (const market of experimentConfig.markets) {
 			bundle = loadBundle();
 		});
 
-		test.beforeEach(async ({ page }) => {
-			await page.goto(urlsConfig.getUrl(market.code));
-		});
+		for (const [pathKey, pathValue] of Object.entries(pagePaths)) {
+			const url = urlsConfig.getUrl(market.code, pathValue);
 
-		test('bundle loads without errors', async ({ page }) => {
-			const errors = [];
-			page.on('pageerror', err => errors.push(err.message));
-			await page.addScriptTag({ content: bundle });
-			expect(errors).toEqual([]);
-		});
+			test.describe(pathKey, () => {
+				test.beforeEach(async ({ page }) => {
+					await page.goto(url, { waitUntil: 'domcontentloaded' });
+				});
 
-		test('experiment component appears after injection', async ({ page }) => {
-			await page.addScriptTag({ content: bundle });
-			const component = page.locator('{{COMPONENT_SELECTOR}}');
-			await expect(component).toBeVisible();
-		});
+				test('bundle loads without errors', async ({ page }) => {
+					const errors = [];
+					page.on('pageerror', err => errors.push(err.message));
+					await page.addScriptTag({ content: bundle });
+					expect(errors).toEqual([]);
+				});
 
-		test('control page is unmodified before injection', async ({ page }) => {
-			// Verify the experiment component does NOT appear without the bundle
-			const component = page.locator('{{COMPONENT_SELECTOR}}');
-			await expect(component).not.toBeVisible();
-		});
+				test('experiment component appears after injection', async ({ page }) => {
+					await page.addScriptTag({ content: bundle });
+					const component = page.locator('{{COMPONENT_SELECTOR}}');
+					await expect(component).toBeVisible();
+				});
+
+				test('control page is unmodified before injection', async ({ page }) => {
+					const component = page.locator('{{COMPONENT_SELECTOR}}');
+					await expect(component).not.toBeVisible();
+				});
+			});
+		}
 	});
 }

--- a/tests/page-paths.test.js
+++ b/tests/page-paths.test.js
@@ -1,0 +1,45 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { PAGE_PATH_CHOICES, buildPagePathsJs, getPagePathPromptChoices } from '../src/page-paths.js';
+
+test('PAGE_PATH_CHOICES is a non-empty array with all 4 page types', () => {
+	assert.ok(Array.isArray(PAGE_PATH_CHOICES));
+	assert.ok(PAGE_PATH_CHOICES.length >= 60, `expected >=60 entries, got ${PAGE_PATH_CHOICES.length}`);
+	const types = new Set(PAGE_PATH_CHOICES.map(c => c.type));
+	assert.deepEqual([...types].sort(), ['BUY', 'PCD', 'PDP', 'PFP']);
+});
+
+test('each choice has title, value, path, and type fields', () => {
+	const validTypes = new Set(['PFP', 'PCD', 'PDP', 'BUY']);
+	for (const choice of PAGE_PATH_CHOICES) {
+		assert.ok(typeof choice.title === 'string', `title missing on ${JSON.stringify(choice)}`);
+		assert.ok(typeof choice.value === 'string', `value missing on ${JSON.stringify(choice)}`);
+		assert.ok(typeof choice.path === 'string', `path missing on ${JSON.stringify(choice)}`);
+		assert.ok(choice.path.startsWith('/'), `path must start with / on ${choice.value}`);
+		assert.ok(validTypes.has(choice.type), `invalid type "${choice.type}" on ${choice.value}`);
+	}
+});
+
+test('buildPagePathsJs generates correct JS object literal from selections', () => {
+	const selections = [
+		{ value: 'pfpTvsAll', path: '/tvs/all-tvs/', type: 'PFP' },
+		{ value: 'pfpTvsOled', path: '/tvs/oled-tvs/', type: 'PFP' },
+	];
+	const result = buildPagePathsJs(selections);
+	assert.ok(result.includes("pfpTvsAll: '/tvs/all-tvs/'"), `missing pfpTvsAll in:\n${result}`);
+	assert.ok(result.includes("pfpTvsOled: '/tvs/oled-tvs/'"), `missing pfpTvsOled in:\n${result}`);
+	assert.ok(result.startsWith('export const pagePaths = {'), `wrong start:\n${result}`);
+	assert.ok(result.trimEnd().endsWith('};'), `wrong end:\n${result}`);
+});
+
+test('buildPagePathsJs generates TODO comment when no selections', () => {
+	const result = buildPagePathsJs([]);
+	assert.ok(result.includes('// TODO'), `should contain TODO comment:\n${result}`);
+	assert.ok(result.startsWith('export const pagePaths = {'), `wrong start:\n${result}`);
+});
+
+test('value keys in PAGE_PATH_CHOICES are unique', () => {
+	const values = PAGE_PATH_CHOICES.map(c => c.value);
+	const unique = new Set(values);
+	assert.equal(unique.size, values.length, 'duplicate value keys found');
+});

--- a/tests/page-paths.test.js
+++ b/tests/page-paths.test.js
@@ -43,3 +43,30 @@ test('value keys in PAGE_PATH_CHOICES are unique', () => {
 	const unique = new Set(values);
 	assert.equal(unique.size, values.length, 'duplicate value keys found');
 });
+
+test('buildPagePathsJs handles single selection', () => {
+	const result = buildPagePathsJs([{ value: 'pfpTvsAll', path: '/tvs/all-tvs/', type: 'PFP' }]);
+	assert.ok(result.includes("pfpTvsAll: '/tvs/all-tvs/'"));
+	assert.ok(result.startsWith('export const pagePaths = {'));
+	assert.ok(result.trimEnd().endsWith('};'));
+});
+
+test('buildPagePathsJs output is valid JS structure (parseable)', () => {
+	const selections = PAGE_PATH_CHOICES.slice(0, 5);
+	const result = buildPagePathsJs(selections);
+	const body = result.replace('export const pagePaths = ', 'const pagePaths = ');
+	assert.doesNotThrow(() => new Function(body));
+});
+
+test('buildPagePathsJs handles null input gracefully', () => {
+	const result = buildPagePathsJs(null);
+	assert.ok(result.includes('// TODO'));
+});
+
+test('getPagePathPromptChoices inserts separator headers between types', () => {
+	const choices = getPagePathPromptChoices();
+	const separators = choices.filter(c => c.disabled);
+	assert.equal(separators.length, 4, 'should have one separator per page type');
+	const selectable = choices.filter(c => !c.disabled);
+	assert.ok(selectable.every(c => !String(c.value).startsWith('__sep_')), 'selectable entries must not have __sep_ values');
+});


### PR DESCRIPTION
  feat: page-path scaffolding — multi-page experiment test generation                                                                                                                     
  Problem                                                                                                     
                                                                                                              
  Previously the generator hardcoded /smartphones/ as the test URL path for every experiment, leaving         
  engineers a manual TODO to replace it. Experiments often run across multiple page types (PFP listing pages, 
  PCD category hubs, PDP product detail pages, buy pages), and there was no way to scaffold tests for multiple
   paths at generation time.

  Solution

  Added a new interactive multiselect step to the generator that lets engineers pick which Samsung page paths
  their experiment targets. The generator then scaffolds a pre-filled page-paths.config.js and updates
  experiment-test.spec.js to run every test for every market × pagePath combination — automatically, with no
  manual editing required.

  ---
  Changes

  New module — src/page-paths.js

  - PAGE_PATH_CHOICES — catalogue of 75 Samsung page paths across 4 types:
    - PFP — Product Filter/Listing pages (e.g. /tvs/all-tvs/, /smartphones/galaxy-s/)
    - PCD — Product Category/Department hubs (e.g. /tvs/, /smartphones/)
    - PDP — Product Detail Pages (e.g. /smartphones/galaxy-s25/)
    - BUY — Purchase pages (e.g. /smartphones/galaxy-s25/buy/)
  - getPagePathPromptChoices() — builds the multiselect choices array with non-selectable type-separator
  headers so the terminal UI is scannable
  - buildPagePathsJs(selections) — converts selected entries to a JS object literal string for template
  injection; falls back to a // TODO comment when no paths are selected

  New prompt step — src/prompts.js

  - Added getPagePathSelections() — a grouped multiselect prompt (space to select, enter to confirm) that
  returns the full { value, path, type } objects for each selection

  Generator pipeline — src/generator.js

  - getPagePathSelections() is called after the configuration summary and before the component selector scan
  - Selected paths are stored on config.pagePaths and passed through to file generation

  Template variable — src/file-operations.js

  - Added PAGE_PATHS_JS to the template variables object, computed via buildPagePathsJs(config.pagePaths ??
  [])
  - Added tests/config/page-paths.config.js to fileMappings and getGeneratedFilesList()

  New generated file — templates/tests/config/page-paths.config.js

  // Generated output example (4 paths selected):
  export const pagePaths = {
      pfpTvsAll: '/tvs/all-tvs/',
      pfpTvsQled: '/tvs/qled-tvs/',
      pcdTvs: '/tvs/',
      pdpGalaxyS25: '/smartphones/galaxy-s25/',
  };

  Updated template — templates/tests/config/urls.config.js

  - getUrl(marketCode) → getUrl(marketCode, pagePath) — composes the full URL from market urlPath + the
  selected page path segment
  - Removed the hardcoded /smartphones/ TODO

  Updated template — templates/tests/e2e/experiment-name/experiment-test.spec.js

  - Replaced the single market loop with a nested market × pagePath loop
  - Imports pagePaths from the new page-paths.config.js
  - Each inner test.describe(pathKey) block gets its own beforeEach that navigates to the correct URL for that
   market + path

  ---
  Before vs After

  Before — one set of tests per market, hardcoded URL:
  COE-123 — Belgium (NL) (BE)
    ✓ bundle loads without errors
    ✓ experiment component appears after injection
    ✓ control page is unmodified before injection

  After — full matrix of market × page path:
  COE-123 — Belgium (NL) (BE)
    pfpTvsAll
      ✓ bundle loads without errors
      ✓ experiment component appears after injection
      ✓ control page is unmodified before injection
    pfpTvsQled
      ✓ bundle loads without errors
      ...
    pdpGalaxyS25

  ---
  Tests

  - 9 new unit tests in tests/page-paths.test.js covering:
    - Catalogue shape validation (all 4 types present, ≥60 entries, unique keys)
    - buildPagePathsJs — multi-selection, single selection, empty/null fallback, parseable JS output
    - getPagePathPromptChoices — correct separator count (4), no __sep_ values in selectable entries
  - Full suite: 82 tests, 0 failures (was 73 before this PR)